### PR TITLE
Gnome 42 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
         "3.36",
         "3.38",
         "40",
-        "41"
+        "41",
+        "42"
     ],
     "url": "https://github.com/gedzeppelin/monitor-window-switcher",
     "uuid": "monitor-window-switcher@thefungusrocket.com",


### PR DESCRIPTION
Updated metadata to add Gnome 42. I'm not sure if anything else needs changed to support Gnome 42. However it's been working fine for me with this change. 

Fixes #8 